### PR TITLE
Changes for async API (non-blocking reqwest)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path="src/lib.rs"
 [dependencies]
 lazy_static = "1.4"
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.10", features = ["blocking", "json"] }
+reqwest = { version = "0.10", features = ["json"] }
 custom_error = "1.7.1"
 percent-encoding = "2.1.0"
 url = "2.1"
@@ -25,3 +25,4 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 enum-map = "0.6.2"
+futures = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ name="newsapi"
 path="src/lib.rs"
 
 [dependencies]
-lazy_static = "1.4"
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.10", features = ["json"] }
 custom_error = "1.7.1"
-percent-encoding = "2.1.0"
-url = "2.1"
-serde = "1.0"
-serde_json = "1.0"
-serde_derive = "1.0"
 enum-map = "0.6.2"
-futures = "0.3.4"
+lazy_static = "1.4"
+percent-encoding = "2.1.0"
+reqwest = { version = "0.10", features = ["blocking", "json"] }
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+tokio = { version = "0.2", features = ["full"] }
+url = "2.1"

--- a/examples/get_articles.rs
+++ b/examples/get_articles.rs
@@ -3,6 +3,7 @@ use chrono::Duration;
 use newsapi::api::Client;
 use newsapi::constants::{Category, Language, SortMethod};
 use newsapi::payload::article::Articles;
+use futures::executor;
 
 use std::env;
 
@@ -34,7 +35,7 @@ fn main() {
     println!("{:?}", c);
 
     // fire off a request to the endpoint and deserialize the results into an Article struct
-    let articles = c.send::<Articles>().unwrap();
+    let articles = executor::block_on(c.send::<Articles>()).unwrap();
 
     // print the results to the terminal
     println!("{:?}", articles);

--- a/examples/get_articles.rs
+++ b/examples/get_articles.rs
@@ -1,9 +1,9 @@
 use chrono::prelude::*;
 use chrono::Duration;
+use futures::executor;
 use newsapi::api::Client;
 use newsapi::constants::{Category, Language, SortMethod};
 use newsapi::payload::article::Articles;
-use futures::executor;
 
 use std::env;
 

--- a/examples/get_articles_sync.rs
+++ b/examples/get_articles_sync.rs
@@ -6,8 +6,7 @@ use newsapi::payload::article::Articles;
 
 use std::env;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let key = env::var("NEWSAPI_KEY").unwrap();
 
     let start_timestamp = Utc::now() - Duration::days(10);
@@ -35,7 +34,7 @@ async fn main() {
     println!("{:?}", c);
 
     // fire off a request to the endpoint and deserialize the results into an Article struct
-    let articles = c.send::<Articles>().await.unwrap();
+    let articles = c.send_sync::<Articles>().unwrap();
 
     // print the results to the terminal
     println!("{:?}", articles);

--- a/examples/get_sources.rs
+++ b/examples/get_sources.rs
@@ -2,8 +2,8 @@ use newsapi::api::Client;
 use newsapi::constants::Language;
 use newsapi::payload::source::Sources;
 
-use std::env;
 use futures::executor;
+use std::env;
 
 fn main() {
     let key = env::var("NEWSAPI_KEY").unwrap();
@@ -13,7 +13,7 @@ fn main() {
         Client::new(key)
             .language(Language::English)
             .sources()
-            .send::<Sources>()
+            .send::<Sources>(),
     );
 
     println!("{:?}", sources)

--- a/examples/get_sources.rs
+++ b/examples/get_sources.rs
@@ -3,15 +3,18 @@ use newsapi::constants::Language;
 use newsapi::payload::source::Sources;
 
 use std::env;
+use futures::executor;
 
 fn main() {
     let key = env::var("NEWSAPI_KEY").unwrap();
 
     // search for English language Sources
-    let sources = Client::new(key)
-        .language(Language::English)
-        .sources()
-        .send::<Sources>();
+    let sources = executor::block_on(
+        Client::new(key)
+            .language(Language::English)
+            .sources()
+            .send::<Sources>()
+    );
 
     println!("{:?}", sources)
 }

--- a/examples/get_sources_sync.rs
+++ b/examples/get_sources_sync.rs
@@ -4,16 +4,14 @@ use newsapi::payload::source::Sources;
 
 use std::env;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let key = env::var("NEWSAPI_KEY").unwrap();
 
     // search for English language Sources
     let sources = Client::new(key)
         .language(Language::English)
         .sources()
-        .send::<Sources>()
-        .await;
+        .send_sync::<Sources>();
 
     println!("{:?}", sources)
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,4 @@
 use enum_map::{enum_map, Enum, EnumMap};
-use lazy_static;
 
 pub const TOP_HEADLINES_URL: &str = "https://newsapi.org/v2/top-headlines";
 


### PR DESCRIPTION
Implements `async send()` + `async fetch_resource()` and implements changes for the new usage (+examples). 

This change is required to enable the API to be used in async scopes using async runtime, like actix-web 2.0. Otherwise, a "trying to block into async thread" [sic] error occurs.

The examples use `futures` crate to keep the code as close to the last version as possible.

I was able to test into my own private chatbot, it's working as expected.

This should probably become a 4.x version.