### PR TITLE
Function name cleanups, light refactors, doc and version updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,4 @@
 # editorconfig.org
-
 root = true
 
 [*]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
-name = "newsapi"
-version = "0.3.1"
 authors = ["biomunky", "lotia"]
+categories = ["api-bindings"]
+description = "Wrapper for the newsapi, uses reqwest to do the http work. A learn by doing project"
 edition = "2018"
 homepage = "https://github.com/biomunky/newsapi"
-description = "Wrapper for the newsapi, uses reqwest to do the http work. A learn by doing project"
 keywords = ["newsapi", "client"]
 license = "MIT/Apache-2.0"
+name = "newsapi"
 readme = "README.md"
-categories = ["api-bindings"]
+version = "0.3.1"
 
 [lib]
-name="newsapi"
-path="src/lib.rs"
+name = "newsapi"
+path = "src/lib.rs"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
+chrono = {version = "0.4", features = ["serde"]}
 custom_error = "1.8"
-enum-map = "0.6.2"
+enum-map = "0.6"
 lazy_static = "1.4"
-percent-encoding = "2.1.0"
-reqwest = { version = "0.10", features = ["blocking", "json"] }
+percent-encoding = "2.1"
+reqwest = {version = "0.10", features = ["blocking", "json"]}
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio = { version = "0.3", features = ["full"] }
+tokio = {version = "0.3", features = ["full"]}
 url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path="src/lib.rs"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-custom_error = "1.7.1"
+custom_error = "1.8"
 enum-map = "0.6.2"
 lazy_static = "1.4"
 percent-encoding = "2.1.0"
@@ -24,5 +24,5 @@ reqwest = { version = "0.10", features = ["blocking", "json"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["full"] }
-url = "2.1"
+tokio = { version = "0.3", features = ["full"] }
+url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["newsapi", "client"]
 license = "MIT/Apache-2.0"
 name = "newsapi"
 readme = "README.md"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 name = "newsapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ reqwest = {version = "0.10", features = ["blocking", "json"]}
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio = {version = "0.3", features = ["full"]}
+tokio = {version = "0.2", features = ["full"]}
 url = "2.2"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 [The News API](https://newsapi.org/) allows you to get breaking news headlines, and search for articles from over 30,000 news sources and blogs.
 
+**Breaking changes**
+
+Version 0.4.x introduces async fetch. While synchronous functionality is retained, the relevant functions have been renamed. Please check [examples/](examples/) for further details. The core change is `send` has been replaced with `send_async` and `send_sync` for the asynchronous and synchronous variants respectively.
+
 All you need is an API key to
 
 - Search live top headlines or search all articles
@@ -39,7 +43,7 @@ Top Headlines and Everything endpoints are wrapped by an Article struct and Sour
 
 ## Examples
 
-As described in [The Cargo Book](https://doc.rust-lang.org/cargo/guide/project-layout.html) the project has some simple examples in examples/. These can be run via cargo after you've exported your NEWSAPI_KEY
+As described in [The Cargo Book](https://doc.rust-lang.org/cargo/guide/project-layout.html) the project has some simple examples in [examples/](examples/). These can be run via cargo after you've exported your NEWSAPI_KEY
 
 ```shell
 export NEWSAPI_KEY=5h79off128957edb3179y5da1nb36y9e
@@ -52,7 +56,7 @@ cargo run --example
 
 to run a specific example
 ```shell
-cargo run --example get_sources
+cargo run --example get_sources_async
 ```
 
 ## License

--- a/examples/get_articles_async.rs
+++ b/examples/get_articles_async.rs
@@ -35,7 +35,7 @@ async fn main() {
     println!("{:?}", c);
 
     // fire off a request to the endpoint and deserialize the results into an Article struct
-    let articles = c.send::<Articles>().await.unwrap();
+    let articles = c.send_async::<Articles>().await.unwrap();
 
     // print the results to the terminal
     println!("{:?}", articles);

--- a/examples/get_sources_async.rs
+++ b/examples/get_sources_async.rs
@@ -12,7 +12,7 @@ async fn main() {
     let sources = Client::new(key)
         .language(Language::English)
         .sources()
-        .send::<Sources>()
+        .send_async::<Sources>()
         .await;
 
     println!("{:?}", sources)

--- a/src/api.rs
+++ b/src/api.rs
@@ -147,12 +147,13 @@ impl Client {
     }
 
     fn create_user_agent() -> String {
-      concat!(
-          "rust-",
-          env!("CARGO_PKG_NAME"),
-          "/",
-          env!("CARGO_PKG_VERSION"),
-      ).to_owned()
+        concat!(
+            "rust-",
+            env!("CARGO_PKG_NAME"),
+            "/",
+            env!("CARGO_PKG_VERSION"),
+        )
+        .to_owned()
     }
 
     async fn fetch_resource_async(url: &str, api_key: &str) -> Result<String, NewsApiError> {


### PR DESCRIPTION
## What?

5ad7160 Update docs and bump version number

   - Link to examples dir
   - Update name in example run command
   - Bump version number

bc19ce9 Downgrade tokio to 0.2.x

   Reqwests 10.x and tokio 0.3.x do not get on at present. The _async_ 
   examples break as a result of this not getting on. So tokio needs to be 
   downgraded to 0.2.x :(.

332b9b6 editorconfig cleanup

   Remove extraneous whitespace

1cd4927 update crates

   - Remove patch version from all specified crates
   - Whitespace cleanups in Cargo.toml

a63c0e6 Run cargo fmt

8b966c8 Update dependencies and remove patch versions

39998df Explicitly name async and sync functions

## Why?

Thanks to a very kind PR from @leodutra, this crate now has async
functionality. These changes make the sync and async bits explicit.

## How to review?

- Eyeball the documentation
- Run the tests
- Run the examples. *We should have some integration tests which run so we
  don't need to manually run examples.*

## Who can review?

@biomunky because he is the custodian of this library.