### PR TITLE
Rename Client to NewsAPIClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["newsapi", "client"]
 license = "MIT/Apache-2.0"
 name = "newsapi"
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 
 [lib]
 name = "newsapi"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://github.com/biomunky/newsapi/workflows/CI/badge.svg)](https://github.com/biomunky/newsapi/actions?query=workflow%3ACI)
 
 - [The News API Rust Library](#the-news-api-rust-library)
+  - [Breaking changes**](#breaking-changes)
+  - [Summary](#summary)
   - [Notes](#notes)
   - [Examples](#examples)
   - [License](#license)
@@ -10,9 +12,13 @@
 
 [The News API](https://newsapi.org/) allows you to get breaking news headlines, and search for articles from over 30,000 news sources and blogs.
 
-**Breaking changes**
+## Breaking changes**
 
-Version 0.4.x introduces async fetch. While synchronous functionality is retained, the relevant functions have been renamed. Please check [examples/](examples/) for further details. The core change is `send` has been replaced with `send_async` and `send_sync` for the asynchronous and synchronous variants respectively.
+- Version 0.5.x renames the `Client` struct to `NewsAPIClient`. See [examples](examples/) for demonstrated usage.
+
+- Version 0.4.x introduces async fetch. While synchronous functionality is retained, the relevant functions have been renamed. Please check [examples](examples/) for further details. The core change is `send` has been replaced with `send_async` and `send_sync` for the asynchronous and synchronous variants respectively.
+
+## Summary
 
 All you need is an API key to
 
@@ -50,11 +56,13 @@ export NEWSAPI_KEY=5h79off128957edb3179y5da1nb36y9e
 ```
 
 To list all examples:
+
 ```shell
 cargo run --example
 ```
 
 to run a specific example
+
 ```shell
 cargo run --example get_sources_async
 ```

--- a/examples/get_articles_async.rs
+++ b/examples/get_articles_async.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 use chrono::Duration;
-use newsapi::api::Client;
+use newsapi::api::NewsAPIClient;
 use newsapi::constants::{Category, Language, SortMethod};
 use newsapi::payload::article::Articles;
 
@@ -14,7 +14,7 @@ async fn main() {
     let end_timestamp = Utc::now();
 
     // create a client
-    let mut c = Client::new(key);
+    let mut c = NewsAPIClient::new(key);
 
     c
         // Search German news sources for articles

--- a/examples/get_articles_sync.rs
+++ b/examples/get_articles_sync.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 use chrono::Duration;
-use newsapi::api::Client;
+use newsapi::api::NewsAPIClient;
 use newsapi::constants::{Category, Language, SortMethod};
 use newsapi::payload::article::Articles;
 
@@ -13,7 +13,7 @@ fn main() {
     let end_timestamp = Utc::now();
 
     // create a client
-    let mut c = Client::new(key);
+    let mut c = NewsAPIClient::new(key);
 
     c
         // Search German news sources for articles

--- a/examples/get_sources_async.rs
+++ b/examples/get_sources_async.rs
@@ -1,4 +1,4 @@
-use newsapi::api::Client;
+use newsapi::api::NewsAPIClient;
 use newsapi::constants::Language;
 use newsapi::payload::source::Sources;
 
@@ -9,7 +9,7 @@ async fn main() {
     let key = env::var("NEWSAPI_KEY").unwrap();
 
     // search for English language Sources
-    let sources = Client::new(key)
+    let sources = NewsAPIClient::new(key)
         .language(Language::English)
         .sources()
         .send_async::<Sources>()

--- a/examples/get_sources_sync.rs
+++ b/examples/get_sources_sync.rs
@@ -1,4 +1,4 @@
-use newsapi::api::Client;
+use newsapi::api::NewsAPIClient;
 use newsapi::constants::Language;
 use newsapi::payload::source::Sources;
 
@@ -8,7 +8,7 @@ fn main() {
     let key = env::var("NEWSAPI_KEY").unwrap();
 
     // search for English language Sources
-    let sources = Client::new(key)
+    let sources = NewsAPIClient::new(key)
         .language(Language::English)
         .sources()
         .send_sync::<Sources>();

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,21 +7,21 @@ use std::collections::HashMap;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 #[derive(Debug)]
-pub struct Client {
+pub struct NewsAPIClient {
     api_key: String,
     parameters: HashMap<String, String>,
     url: Option<String>,
 }
 
-impl Client {
+impl NewsAPIClient {
     /// Returns a NewsAPI with given api key
     ///
     /// # Arguments
     ///
     /// * `api_key` - a string that holds the api, this will be used to set X-Api-Key.
     ///
-    pub fn new(api_key: String) -> Client {
-        Client {
+    pub fn new(api_key: String) -> NewsAPIClient {
+        NewsAPIClient {
             api_key,
             parameters: HashMap::new(),
             url: None,
@@ -29,7 +29,7 @@ impl Client {
     }
 
     /// Build the 'fetch everything' url
-    pub fn everything(&mut self) -> &mut Client {
+    pub fn everything(&mut self) -> &mut NewsAPIClient {
         let allowed_params = vec![
             "q",
             "sources",
@@ -48,14 +48,14 @@ impl Client {
     }
 
     /// Build the 'top_headlines' url
-    pub fn top_headlines(&mut self) -> &mut Client {
+    pub fn top_headlines(&mut self) -> &mut NewsAPIClient {
         let allowed_params = vec!["q", "country", "category", "sources", "pageSize", "page"];
         self.url = Some(self.build_url(constants::TOP_HEADLINES_URL, allowed_params));
         self
     }
 
     /// Build the 'sources' url
-    pub fn sources(&mut self) -> &mut Client {
+    pub fn sources(&mut self) -> &mut NewsAPIClient {
         let allowed_params = vec!["category", "language", "country"];
         self.url = Some(self.build_url(constants::SOURCES_URL, allowed_params));
         self
@@ -72,7 +72,7 @@ impl Client {
 
         match &self.url {
             Some(url) => {
-                let body = Client::fetch_resource_async(url, &self.api_key).await?;
+                let body = NewsAPIClient::fetch_resource_async(url, &self.api_key).await?;
                 Ok(serde_json::from_str::<T>(&body)?)
             }
             None => Err(NewsApiError::UndefinedUrlError),
@@ -90,7 +90,7 @@ impl Client {
 
         match &self.url {
             Some(url) => {
-                let body = Client::fetch_resource_sync(url, &self.api_key)?;
+                let body = NewsAPIClient::fetch_resource_sync(url, &self.api_key)?;
                 Ok(serde_json::from_str::<T>(&body)?)
             }
             None => Err(NewsApiError::UndefinedUrlError),
@@ -159,7 +159,7 @@ impl Client {
     async fn fetch_resource_async(url: &str, api_key: &str) -> Result<String, NewsApiError> {
         // TODO: create a client that can be reused
         let client = reqwest::Client::builder()
-            .user_agent(self::Client::create_user_agent())
+            .user_agent(NewsAPIClient::create_user_agent())
             .build()?;
 
         let resp = client.get(url).header("X-Api-Key", api_key).send().await?;
@@ -167,7 +167,7 @@ impl Client {
         if resp.status().is_success() {
             Ok(resp.text().await?)
         } else {
-            Err(Client::handle_api_error(
+            Err(NewsAPIClient::handle_api_error(
                 resp.status().as_u16(),
                 resp.text().await?,
             ))
@@ -177,7 +177,7 @@ impl Client {
     fn fetch_resource_sync(url: &str, api_key: &str) -> Result<String, NewsApiError> {
         // TODO: create a client that can be reused
         let client = reqwest::blocking::Client::builder()
-            .user_agent(self::Client::create_user_agent())
+            .user_agent(NewsAPIClient::create_user_agent())
             .build()?;
 
         let resp = client.get(url).header("X-Api-Key", api_key).send()?;
@@ -185,7 +185,7 @@ impl Client {
         if resp.status().is_success() {
             Ok(resp.text()?)
         } else {
-            Err(Client::handle_api_error(
+            Err(NewsAPIClient::handle_api_error(
                 resp.status().as_u16(),
                 resp.text()?,
             ))
@@ -193,13 +193,13 @@ impl Client {
     }
 
     /// A date and optional time for the oldest article allowed
-    pub fn from(&mut self, from: &DateTime<Utc>) -> &mut Client {
+    pub fn from(&mut self, from: &DateTime<Utc>) -> &mut NewsAPIClient {
         self.chronological_specification("from", from);
         self
     }
 
     /// A date and optional time for the newest article allowed.
-    pub fn to(&mut self, to: &DateTime<Utc>) -> &mut Client {
+    pub fn to(&mut self, to: &DateTime<Utc>) -> &mut NewsAPIClient {
         self.chronological_specification("to", to);
         self
     }
@@ -208,7 +208,7 @@ impl Client {
         &mut self,
         operation: &str,
         dt_val: &DateTime<Utc>,
-    ) -> &mut Client {
+    ) -> &mut NewsAPIClient {
         let dt_format = "%Y-%m-%dT%H:%M:%S";
         self.parameters
             .insert(operation.to_owned(), dt_val.format(dt_format).to_string());
@@ -217,7 +217,7 @@ impl Client {
 
     ///  The domains
     /// (e.g. bbc.co.uk, techcrunch.com, engadget.com) to which search will be restricted.
-    pub fn domains(&mut self, domains: Vec<&str>) -> &mut Client {
+    pub fn domains(&mut self, domains: Vec<&str>) -> &mut NewsAPIClient {
         self.manage_domains("domains", domains);
         self
     }
@@ -225,19 +225,19 @@ impl Client {
     /// The domains
     /// (e.g. bbc.co.uk, techcrunch.com, engadget.com) from which no stories will be present in the
     /// results.
-    pub fn exclude_domains(&mut self, domains: Vec<&str>) -> &mut Client {
+    pub fn exclude_domains(&mut self, domains: Vec<&str>) -> &mut NewsAPIClient {
         self.manage_domains("excludeDomains", domains);
         self
     }
 
-    fn manage_domains(&mut self, operation: &str, domains: Vec<&str>) -> &mut Client {
+    fn manage_domains(&mut self, operation: &str, domains: Vec<&str>) -> &mut NewsAPIClient {
         self.parameters
             .insert(operation.to_owned(), domains.join(","));
         self
     }
 
     /// Narrow search to specific country
-    pub fn country(&mut self, country: constants::Country) -> &mut Client {
+    pub fn country(&mut self, country: constants::Country) -> &mut NewsAPIClient {
         self.parameters.insert(
             "country".to_owned(),
             constants::COUNTRY_LOOKUP[country].to_string(),
@@ -246,7 +246,7 @@ impl Client {
     }
 
     /// Defaults to all categories - see constants.rs
-    pub fn category(&mut self, category: constants::Category) -> &mut Client {
+    pub fn category(&mut self, category: constants::Category) -> &mut NewsAPIClient {
         let fmtd_category = format!("{:?}", category).to_lowercase();
         self.parameters.insert("category".to_owned(), fmtd_category);
         self
@@ -255,7 +255,7 @@ impl Client {
     /// Use the /sources endpoint to locate these programmatically or look at the sources index.
     /// Note: you can't mix this param with the country or category params.
     /// This will be checked before calling the API but you can still get rekt!
-    pub fn with_sources(&mut self, sources: String) -> &mut Client {
+    pub fn with_sources(&mut self, sources: String) -> &mut NewsAPIClient {
         self.parameters.insert("sources".to_owned(), sources);
         self
     }
@@ -267,7 +267,7 @@ impl Client {
     /// * Prepend words that must not appear with a - symbol. Eg: -bitcoin
     /// * Alternatively you can use the AND / OR / NOT keywords, and optionally group these with parenthesis.
     ///   e.g.: crypto AND (ethereum OR litecoin) NOT bitcoin
-    pub fn query(&mut self, query: &str) -> &mut Client {
+    pub fn query(&mut self, query: &str) -> &mut NewsAPIClient {
         self.parameters.insert(
             "q".to_owned(),
             utf8_percent_encode(&query, NON_ALPHANUMERIC).to_string(),
@@ -275,12 +275,12 @@ impl Client {
         self
     }
 
-    pub fn page(&mut self, page: u32) -> &mut Client {
+    pub fn page(&mut self, page: u32) -> &mut NewsAPIClient {
         self.parameters.insert("page".to_owned(), page.to_string());
         self
     }
 
-    pub fn page_size(&mut self, size: u32) -> &mut Client {
+    pub fn page_size(&mut self, size: u32) -> &mut NewsAPIClient {
         if size >= 1 && size <= 100 {
             self.parameters
                 .insert("pageSize".to_owned(), size.to_string());
@@ -288,7 +288,7 @@ impl Client {
         self
     }
 
-    pub fn language(&mut self, language: constants::Language) -> &mut Client {
+    pub fn language(&mut self, language: constants::Language) -> &mut NewsAPIClient {
         self.parameters.insert(
             "language".to_owned(),
             constants::LANG_LOOKUP[language].to_string(),
@@ -296,7 +296,7 @@ impl Client {
         self
     }
 
-    pub fn sort_by(&mut self, sort_by: constants::SortMethod) -> &mut Client {
+    pub fn sort_by(&mut self, sort_by: constants::SortMethod) -> &mut NewsAPIClient {
         self.parameters.insert(
             "sort_by".to_owned(),
             constants::SORT_METHOD_LOOKUP[sort_by].to_string(),
@@ -311,11 +311,11 @@ mod tests {
 
     #[test]
     fn handle_api_error() {
-        let bad_request = Client::handle_api_error(400, "BadRequest".into());
+        let bad_request = NewsAPIClient::handle_api_error(400, "BadRequest".into());
         assert_eq!(bad_request.to_string(), "BadRequest: 400 => BadRequest");
 
         let generic_error =
-            Client::handle_api_error(418, "Hyper Text Coffee Pot Control Protocol".into());
+            NewsAPIClient::handle_api_error(418, "Hyper Text Coffee Pot Control Protocol".into());
         assert_eq!(
             generic_error.to_string(),
             "GenericError: 418 => Hyper Text Coffee Pot Control Protocol"
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn query() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
         api.query("Ali loves the hoff NOT Baywatch");
         let encoded_param = api.parameters.get("q");
         assert_eq!(
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn build_url() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
         api.language(constants::Language::English);
         api.country(constants::Country::UnitedStatesofAmerica);
         let expected = "https://newsapi.org/v2/sources?language=en&country=us".to_owned();
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn domains() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
 
         assert_eq!(api.parameters.get("domains"), None);
         assert_eq!(api.parameters.get("excludeDomains"), None);
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn category() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
         assert_eq!(api.parameters.get("category"), None);
         api.category(constants::Category::Science);
         assert_eq!(api.parameters.get("category"), Some(&"science".to_owned()));
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn country() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
         assert_eq!(api.parameters.get("country"), None);
         api.country(constants::Country::Germany);
         assert_eq!(api.parameters.get("country"), Some(&"de".to_owned()));
@@ -384,14 +384,14 @@ mod tests {
 
     #[test]
     fn language() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
         api.language(constants::Language::English);
         assert_eq!(api.parameters.get("language"), Some(&"en".to_owned()));
     }
 
     #[test]
     fn to_and_from() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
 
         let from = Utc.ymd(2019, 7, 8).and_hms(9, 10, 11);
         let to = Utc.ymd(2019, 7, 9).and_hms(9, 10, 11);
@@ -410,20 +410,20 @@ mod tests {
 
     #[test]
     fn new() {
-        let api = Client::new("123".to_string());
+        let api = NewsAPIClient::new("123".to_string());
         assert_eq!(api.api_key, "123".to_string());
     }
 
     #[test]
     fn page() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
         api.page(20);
         assert_eq!(api.parameters.get("page"), Some(&"20".to_owned()));
     }
 
     #[test]
     fn page_size() {
-        let mut api = Client::new("123".to_owned());
+        let mut api = NewsAPIClient::new("123".to_owned());
         assert_eq!(api.parameters.get("pageSize"), None);
         api.page_size(30);
         assert_eq!(api.parameters.get("pageSize"), Some(&"30".to_owned()));


### PR DESCRIPTION
Feels like Client makes sense in terms of standalone library, however
when using outside it doesn't.