### PR TITLE
article.title Option<> for missing instances

### DIFF
--- a/src/payload/article.rs
+++ b/src/payload/article.rs
@@ -28,7 +28,7 @@ impl PartialEq for ArticleSource {
 pub struct Article {
     pub source: ArticleSource,
     pub author: Option<String>,
-    pub title: String,
+    pub title: Option<String>,      // This is missing on rare occasion
     pub description: Option<String>,
     pub url: String,
     #[serde(rename = "urlToImage")]

--- a/src/payload/article.rs
+++ b/src/payload/article.rs
@@ -28,7 +28,7 @@ impl PartialEq for ArticleSource {
 pub struct Article {
     pub source: ArticleSource,
     pub author: Option<String>,
-    pub title: Option<String>,      // This is missing on rare occasion
+    pub title: Option<String>,
     pub description: Option<String>,
     pub url: String,
     #[serde(rename = "urlToImage")]


### PR DESCRIPTION
On rare occasion, the article.title field is missing. This leads to a panic on deserialization. Changing the .title field from String to Option<String> fixes this.

As evidence, a diagnostic was performed where the same request was made with python requests. Note the NONE field in one of 100 articles:
>>> [ type(article['title']).__name__ for article in r.json()['articles'] ]
['str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'NoneType', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str']
